### PR TITLE
Catch language AttributeError

### DIFF
--- a/siriServer.py
+++ b/siriServer.py
@@ -283,11 +283,7 @@ class HandleConnection(ssl_dispatcher):
                     self.logger.info("Sending flac to google for recognition")
                     try:
                         self.httpClient.make_google_request(flacBin, finishSpeech.refId, dictation, language=self.assistant.language, allowCurses=True)
-                    except TypeError:
-                        fail = CommandFailed(reqObject['aceId'])
-                        fail.reason = "Database error"
-                        fail.errorCode = 2
-                        self.send_object(fail)
+                    except AttributeError, TypeError:
                         self.logger.info("Unable to find language record for this assistant. Try turning Siri off and then back on.")
                         
                 elif ObjectIsCommand(reqObject, CancelRequest):

--- a/siriServer.py
+++ b/siriServer.py
@@ -281,8 +281,14 @@ class HandleConnection(ssl_dispatcher):
                     del self.speech[finishSpeech.refId]
                     
                     self.logger.info("Sending flac to google for recognition")
-                    self.httpClient.make_google_request(flacBin, finishSpeech.refId, dictation, language=self.assistant.language, allowCurses=True)
-                        
+                    try:
+                        self.httpClient.make_google_request(flacBin, finishSpeech.refId, dictation, language=self.assistant.language, allowCurses=True)
+                    except TypeError:
+                        fail = CommandFailed(reqObject['aceId'])
+                        fail.reason = "Database error"
+                        fail.errorCode = 2
+                        self.send_object(fail)
+                        self.logger.info("Unable to find language record for this assistant. Try turning Siri off and then back on.")
                         
                 elif ObjectIsCommand(reqObject, CancelRequest):
                         # this is probably called when we need to kill a plugin


### PR DESCRIPTION
Bugfix.

Just catches the 'language' AttributeError and prints a warning. Once caught, the server seems to work fine afterwards.

Attached to issues #298, #292.
