### PR TITLE
Fixes to python dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can install both via `easy_install`,
 easy_install is available at [http://pypi.python.org/pypi/setuptools](http://pypi.python.org/pypi/setuptools),
 on Linux you can also get it via your packet manager:
 
-	sudo apt-get install python-setuptools
+	sudo apt-get install python-setuptools libevent-dev python-dev swig
 
 After you installed it, run:
 


### PR DESCRIPTION
Soloutions to fix problems such as "error: Setup script exited with error: command 'gcc' failed with exit status 1" and "unable to execute swig: No such file or directory"
